### PR TITLE
Exclude grizzly artifacts bundled into grizzly-core already

### DIFF
--- a/gms/impl/pom.xml
+++ b/gms/impl/pom.xml
@@ -49,6 +49,16 @@
             <groupId>${grizzly.group.id}</groupId>
             <artifactId>grizzly-core</artifactId>
             <version>${grizzly.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.grizzly</groupId>
+                    <artifactId>grizzly-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.grizzly</groupId>
+                    <artifactId>grizzly-portunif</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Currently `grizzly-core` bundles both `grizzly-framework` and `grizzly-portunif` AND declares them as dependencies in default scope (compile).

This helps to avoid on `shoal-gms-impl` usage:

```
[ERROR] Duplicate classes found:
[ERROR]
[ERROR]   Found in:
[ERROR]     org.glassfish.grizzly:grizzly-framework:jar:4.0.1:compile
[ERROR]     org.glassfish.grizzly:grizzly-core:jar:4.0.1:compile
[ERROR]   Duplicate classes:
[ERROR]     org/glassfish/grizzly/memory/AbstractMemoryManager$TrimAware.class
[ERROR]     org/glassfish/grizzly/ssl/SSLBaseFilter$4.class
...

[ERROR]
[ERROR]   Found in:
[ERROR]     org.glassfish.grizzly:grizzly-core:jar:4.0.1:compile
[ERROR]     org.glassfish.grizzly:grizzly-portunif:jar:4.0.1:compile
[ERROR]   Duplicate classes:
[ERROR]     org/glassfish/grizzly/portunif/finders/HttpProtocolFinder.class
[ERROR]     org/glassfish/grizzly/portunif/PUFilter$SuspendedContextCopyListener.class
...
```

IMO the ideal would be to have it corrected in grizzly itself.