### PR TITLE
Narrow grizzly dependency

### DIFF
--- a/gms/impl/pom.xml
+++ b/gms/impl/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>${grizzly.group.id}</groupId>
-            <artifactId>grizzly-core</artifactId>
+            <artifactId>grizzly-framework</artifactId>
             <version>${grizzly.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Replace
```
[INFO] --- dependency:3.7.0:tree (default-cli) @ shoal-gms-impl ---
[INFO] org.glassfish.shoal:shoal-gms-impl:bundle:3.1.1-SNAPSHOT
[INFO] +- org.glassfish.shoal:shoal-gms-api:jar:3.1.1-SNAPSHOT:compile
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] \- org.glassfish.grizzly:grizzly-core:jar:4.0.2:compile
[INFO]    +- org.glassfish.grizzly:grizzly-framework:jar:4.0.2:compile
[INFO]    \- org.glassfish.grizzly:grizzly-portunif:jar:4.0.2:compile
```
which introduces duplicated classes (`grizzly-core` contains classes from `grizzly-framework` and `grizzly-portunif` AND additionaly depends on these artifacts),
with
```
[INFO] --- dependency:3.7.0:tree (default-cli) @ shoal-gms-impl ---
[INFO] org.glassfish.shoal:shoal-gms-impl:bundle:3.1.1-SNAPSHOT
[INFO] +- org.glassfish.shoal:shoal-gms-api:jar:3.1.1-SNAPSHOT:compile
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] \- org.glassfish.grizzly:grizzly-framework:jar:4.0.2:compile
```